### PR TITLE
Skip processing of channel posts, voice messages, calls, etc.

### DIFF
--- a/telegram-plugin-server/src/main/java/com/notononoto/teamcity/telegram/TelegramBotManager.java
+++ b/telegram-plugin-server/src/main/java/com/notononoto/teamcity/telegram/TelegramBotManager.java
@@ -121,6 +121,9 @@ public class TelegramBotManager {
     bot.setUpdatesListener(updates -> {
       for (Update update: updates) {
         Message message = update.message();
+        if (message == null) {
+          continue;
+        }
         Long chatId = message.chat().id();
         SendMessage msg = new SendMessage(chatId,
             "Hello! Your chat id is '" + chatId + "'.\n" +


### PR DESCRIPTION
Because it leads to message duplication in case when message is null and processing of updates starts from beginning.